### PR TITLE
Simple doc update

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -17,7 +17,7 @@ components of rspec that you're not using.
 
 ## Install
 
-    gem install rspec --prerelease
+    gem install rspec
 
 ## Contribute
 


### PR DESCRIPTION
With RSpec 2 reaching 2.0.0 there's no long a need for the --prerelease flag on gem install!
