### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/rspec.gemspec
+++ b/rspec.gemspec
@@ -14,6 +14,13 @@ Gem::Specification.new do |s|
   s.summary     = "rspec-#{RSpec::Version::STRING}"
   s.description = "BDD for Ruby"
 
+  s.metadata = {
+    'bug_tracker_uri'   => 'https://github.com/rspec/rspec/issues',
+    'documentation_uri' => 'https://rspec.info/documentation/',
+    'mailing_list_uri'  => 'https://groups.google.com/forum/#!forum/rspec',
+    'source_code_uri'   => 'https://github.com/rspec/rspec',
+  }
+
   s.files            = `git ls-files -- lib/*`.split("\n")
   s.files           += ["LICENSE.md"]
   s.test_files       = `git ls-files -- {spec,features}/*`.split("\n")


### PR DESCRIPTION
Following on from rspec/rspec-core#2574.

Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. This'll allow people to more easily access the source code, raise issues and read the documentation. These `bug_tracker_uri`, `documentation_uri`, `mailing_list_uri` and `source_code_uri` links will appear or replace those on the rubygems page at https://rubygems.org/gems/rspec after the next release.